### PR TITLE
fixed incorrect axios import

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -16,8 +16,8 @@ import {FriendbotBuilder} from "./friendbot_builder";
 import {AssetsCallBuilder} from "./assets_call_builder";
 import { TradeAggregationCallBuilder } from "./trade_aggregation_call_builder";
 import axiosRetry from 'axios-retry';
+import axios from 'axios';
 
-const axios = require("axios");
 const URI = require("urijs");
 
 export const SUBMIT_TRANSACTION_TIMEOUT = 60*1000;


### PR DESCRIPTION
This where causing a crash during a KinSdk initialization when accessing axios.interceptors.request instead of axios.default.interceptors.request. It seems it only reproducible in our build but not when lib is used directly. Hope this helps. Kudos.
